### PR TITLE
Remove transfers table from guest page

### DIFF
--- a/config/templates/surf/guests_page.php
+++ b/config/templates/surf/guests_page.php
@@ -210,17 +210,18 @@ use ( $new_guests_can_only_send_to_creator,
     ?>
 </div>
 
-<div class="box">
+<!-- <div class="box">
     <h1>{tr:guests_transfers}</h1>
     
     <?php
 
-    $user_can_only_view_guest_transfers_shared_with_them = Config::get('user_can_only_view_guest_transfers_shared_with_them');
-    $transfers = Transfer::fromGuestsOf(Auth::user(), $user_can_only_view_guest_transfers_shared_with_them);
-    Template::display('transfers_table',
-                      array('transfers' => $transfers,
-                            'show_guest' => true));
+    // $user_can_only_view_guest_transfers_shared_with_them = Config::get('user_can_only_view_guest_transfers_shared_with_them');
+    // $transfers = Transfer::fromGuestsOf(Auth::user(), $user_can_only_view_guest_transfers_shared_with_them);
+    // Template::display('transfers_table',
+    //                   array('transfers' => $transfers,
+    //                         'show_guest' => true));
     ?>
+-->
 </div>
     
 <script type="text/javascript" src="{path:js/guests_page.js}"></script>


### PR DESCRIPTION
Remove transfer overview from my guests, due to privacy considerations