### PR TITLE
Handle transfer options correctly

### DIFF
--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -250,7 +250,7 @@ class RestEndpointGuest extends RestEndpoint
         }
         
         if( strtolower(Config::get('storage_type')) == 'clouds3' ) {
-            $transfer_options = StorageCloudS3::augmentTransferOptions( $options );
+            $transfer_options = StorageCloudS3::augmentTransferOptions( $transfer_options );
         }
 
         if(Auth::isRemote()) {

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -250,7 +250,7 @@ class RestEndpointGuest extends RestEndpoint
         }
         
         if( strtolower(Config::get('storage_type')) == 'clouds3' ) {
-            $options = StorageCloudS3::augmentTransferOptions( $options );
+            $transfer_options = StorageCloudS3::augmentTransferOptions( $options );
         }
 
         if(Auth::isRemote()) {


### PR DESCRIPTION
When using S3 storage and guest vouchers, FileSender loses transfer options due to incorrect variable naming.